### PR TITLE
fix clockwise determination for open paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,11 @@ dev = [
 homepage = "https://github.com/teamtomo/torch-subtract-membranes-2d"
 repository = "https://github.com/teamtomo/torch-subtract-membranes-2d"
 
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]
+
 # Entry points
 # https://peps.python.org/pep-0621/#entry-points
 # same as console_scripts entry point

--- a/uv.lock
+++ b/uv.lock
@@ -2699,6 +2699,11 @@ test = [
     { name = "pytest-cov" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "einops" },
@@ -2721,6 +2726,9 @@ requires-dist = [
     { name = "torch-segment-membranes-2d", specifier = ">=0.0.3" },
 ]
 provides-extras = ["dev", "test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 
 [[package]]
 name = "torchmetrics"


### PR DESCRIPTION
clockwise-ness of paths was incorrect under some conditions for open paths

<img width="559" alt="image" src="https://github.com/user-attachments/assets/8d8d4d56-6dd6-4631-bfd8-6390f0e86f61" />


I've modified this to use an approach based on turning angle rather than signed area
